### PR TITLE
now allows shortcut arguemnts

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -34,10 +34,11 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl
+          extensions: mbstring, intl, pcov
           ini-values: post_max_size=256M, log_errors=1
           tools: pecl
-
+          coverage: pcov
+      
       - name: Check PHP Version
         run: php -v
 
@@ -50,6 +51,11 @@ jobs:
       - name: Install dependencies
         run: composer clearcache && rm -rf composer.lock && composer install --prefer-dist --no-suggest
 
+      - name: Setup PCOV
+        run: |
+          composer require pcov/clobber
+          vendor/bin/pcov clobber
+        
       - name: Run Tests
         env:
           environment_github: true

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "wp-coding-standards/wpcs": "*",
         "object-calisthenics/phpcs-calisthenics-rules": "*",
         "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0",
-        "gin0115/wpunit-helpers": "~1.0.0"
+        "gin0115/wpunit-helpers": "~1.0.0",
+        "pcov/clobber": "^2.0"
     },
     "require": {
         "php": ">=7.1.0",

--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -67,15 +67,15 @@ class Route extends Abstract_Route {
 		// Create capture group for ":parameter"
 		$allowed_chars = '[\@a-zA-Z0-9&.?:-_=#]*';
 		$route         = preg_replace(
-			'/:(' . $allowed_chars . ')/',   # Replace ":parameter"
-			'(?<$1>' . $allowed_chars . ')', # with "(?<parameter>[a-zA-Z0-9\_\-]+)"
+			'/:(' . $allowed_chars . ')/',
+			'(?<$1>' . $allowed_chars . ')',
 			$route
 		);
 
 		// Create capture group for '{parameter}'
 		$route = preg_replace(
-			'/{(' . $allowed_chars . ')}/',    # Replace "{parameter}"
-			'(?<$1>' . $allowed_chars . ')', # with "(?<parameter>[a-zA-Z0-9\_\-]+)"
+			'/{(' . $allowed_chars . ')}/',
+			'(?<$1>' . $allowed_chars . ')',
 			is_string( $route ) ? $route : ''
 		);
 

--- a/src/Route/Route.php
+++ b/src/Route/Route.php
@@ -48,7 +48,38 @@ class Route extends Abstract_Route {
 	 * @return string
 	 */
 	protected function format_route( string $route ): string {
+		$route = $this->translate_arguments( $route );
 		return '/' . ltrim( $route, '/\\' );
+	}
+
+	/**
+	 * Translates shortcut route arguments.
+	 *
+	 * @see https://stackoverflow.com/questions/30130913/how-to-do-url-matching-regex-for-routing-framework
+	 * @param string $route
+	 * @return string
+	 */
+	protected function translate_arguments( string $route ): string {
+		if ( preg_match( '/[^-:\/_{}()a-zA-Z\d]/', $route ) ) {
+			return $route;
+		}
+
+		// Create capture group for ":parameter"
+		$allowed_chars = '[\@a-zA-Z0-9&.?:-_=#]*';
+		$route         = preg_replace(
+			'/:(' . $allowed_chars . ')/',   # Replace ":parameter"
+			'(?<$1>' . $allowed_chars . ')', # with "(?<parameter>[a-zA-Z0-9\_\-]+)"
+			$route
+		);
+
+		// Create capture group for '{parameter}'
+		$route = preg_replace(
+			'/{(' . $allowed_chars . ')}/',    # Replace "{parameter}"
+			'(?<$1>' . $allowed_chars . ')', # with "(?<parameter>[a-zA-Z0-9\_\-]+)"
+			is_string( $route ) ? $route : ''
+		);
+
+		return is_string( $route ) ? $route : '';
 	}
 
 	/**

--- a/tests/Fixtures/Fixture_Route_Shortcut_Args.php
+++ b/tests/Fixtures/Fixture_Route_Shortcut_Args.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Base class for Rest Integration tests.
+ *  
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @since 0.1.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @package PinkCrab\Route
+ */
+
+namespace PinkCrab\Route\Tests\Fixtures;
+
+use PinkCrab\Route\Registration_Middleware\Route_Controller;
+use PinkCrab\Route\Route\Route_Group;
+
+use PinkCrab\Route\Route_Factory;
+use WP_HTTP_Response;
+
+class Fixture_Route_Shortcut_Args extends Route_Controller{
+
+   /**
+	 * The namespace for this controllers routes
+	 *
+	 * @required
+	 * @var string
+	 */
+	protected $namespace = 'pinkcrab/v3';
+   
+    /**
+	 * Method defined to register all routes.
+	 *
+	 * @param Route_Factory $factory
+	 * @return array<Route|Route_Group>
+	 */
+	protected function define_routes( Route_Factory $factory): array{
+        return [
+            
+            $factory->get('shortcut/single-curliness/{dynamic}', [$this, 'get_callback']),
+            $factory->get('shortcut/dual-curliness/{a1}/{a2}', [$this, 'get_callback']),
+            $factory->get('shortcut/single-named/:name1', [$this, 'get_callback']),
+            $factory->get('shortcut/mixed/:arg1/{arg2}', [$this, 'get_callback']),
+
+        ];
+    }
+
+    // CALLBACKS
+
+    public function get_callback($request): WP_HTTP_Response  {
+        return new WP_HTTP_Response( ['method' => 'get'] );
+
+    }
+}

--- a/tests/Fixtures/HTTP_TestCase.php
+++ b/tests/Fixtures/HTTP_TestCase.php
@@ -100,4 +100,9 @@ abstract class HTTP_TestCase extends \WP_UnitTestCase {
 		}
 		return $this->server->dispatch( $request );
 	}
+
+	public function get_server(): \WP_REST_Server
+	{
+		return $this->server;
+	}
 }

--- a/tests/Intergration/Test_Shortcut_Args_Registration.php
+++ b/tests/Intergration/Test_Shortcut_Args_Registration.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Intergration tests for route groups
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @package PinkCrab\Route
+ *
+
+ */
+
+namespace PinkCrab\Route\Tests\Unit\Registration;
+
+use PinkCrab\Route\Utils;
+use Gin0115\WPUnit_Helpers\Objects;
+use PinkCrab\Perique\Application\App;
+use PinkCrab\Perique\Application\App_Factory;
+use PinkCrab\Route\Tests\Fixtures\HTTP_TestCase;
+use PinkCrab\Route\Tests\Fixtures\Fixture_Route_Shortcut_Args;
+
+
+class Test_Shortcut_Args_Registration extends HTTP_TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$app = new App();
+		Objects::set_property( $app, 'app_config', null );
+		Objects::set_property( $app, 'container', null );
+		Objects::set_property( $app, 'registration', null );
+		Objects::set_property( $app, 'loader', null );
+		Objects::set_property( $app, 'booted', false );
+		$app = null;
+	}
+
+	/** @testdox It should be possible to define a route using shortcut (dynamic and named) arguments and have a general rule for allowed symbols. */
+	public function test_as_app_middleware(): void {
+		$middleware = Utils::middleware_provider();
+
+		$app = ( new App_Factory() )->with_wp_dice( true )
+		->app_config( array() )
+		->registration_middleware( $middleware )
+		->registration_classes(
+			array(
+				Fixture_Route_Shortcut_Args::class,
+			)
+		)
+		->boot();
+
+		// Run wp setup for routing and app intialisation.
+		do_action( 'init' );
+		$this->register_routes();
+
+		$namespace = '/pinkcrab/v3/';
+
+		// Check with valid single curlies
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/single-curliness/foo' )->get_status() );
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/single-curliness/allow12345' )->get_status() );
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/single-curliness/allow&.:_=#@?' )->get_status() );
+
+		// Double curlies
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/dual-curliness/allow12345/allow&.:_=#@?' )->get_status() );
+
+		// Single named
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/single-named/foo' )->get_status() );
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/single-named/allow12345' )->get_status() );
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/single-named/allow&.:_=#@?' )->get_status() );
+
+		// Mixed
+		$this->assertEquals( 200, $this->dispatch_request( 'GET', $namespace . 'shortcut/mixed/allow12345/allow&.:_=#@?' )->get_status() );
+	}
+
+}

--- a/tests/Unit/Route/Test_Route.php
+++ b/tests/Unit/Route/Test_Route.php
@@ -64,7 +64,7 @@ class Test_Route extends WP_UnitTestCase {
 		$route = new Route( 'GET', '/route' );
 		$route->callback(
 			function( \WP_REST_Request $request ) {
-				return  array( 'success', 200 );
+				return array( 'success', 200 );
 			}
 		);
 
@@ -113,5 +113,14 @@ class Test_Route extends WP_UnitTestCase {
 
 		$route_with = new Route( 'get', '/with' );
 		$this->assertEquals( '/with', $route_with->get_route() );
+	}
+
+	/** @testdox It should be possible to use shortcut argument deifnitions. */
+	public function test_shortcut_arg_definition() {
+		$curlies = new Route( 'get', 'curlies/{param1}/{param2}' );
+		$this->assertEquals( '/curlies/(?<param1>[\@a-zA-Z0-9&.?:-_=#]*)/(?<param2>[\@a-zA-Z0-9&.?:-_=#]*)', $curlies->get_route() );
+
+		$curlies = new Route( 'get', 'named/:param1' );
+		$this->assertEquals( '/named/(?<param1>[\@a-zA-Z0-9&.?:-_=#]*)', $curlies->get_route() );
 	}
 }


### PR DESCRIPTION
Allows for the use of 

/foo/{argument} and /foo/:argument in route definitions.